### PR TITLE
update swift41 snapshot build to 2018-03-11-a

### DIFF
--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -51,3 +51,5 @@ runtimes_manifest:
 
   blackboxes:
     - name: "dockerskeleton"
+
+controller_protocol: "http"

--- a/swift4.1/CHANGELOG.md
+++ b/swift4.1/CHANGELOG.md
@@ -1,5 +1,14 @@
 # IBM Functions Swift 4.1 Runtime 
 
+## 1.0.2
+Changes:
+  - update swift41 snapshot build to `2018-03-11-a`
+
+Swift runtime version: [swift-4.1-DEVELOPMENT-SNAPSHOT-2018-03-07-a](https://swift.org/builds/swift-4.1-branch/ubuntu1404/swift-4.1-DEVELOPMENT-SNAPSHOT-2018-03-11-a/swift-4.1-DEVELOPMENT-SNAPSHOT-2018-03-11-a-ubuntu14.04.tar.gz)
+
+Packages included:
+  - [Watson SDK 0.21.0](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/v0.21.0)
+
 ## 1.0.1
 Changes:
   - update swift41 snapshot build to `2018-03-07-a`

--- a/swift4.1/Dockerfile
+++ b/swift4.1/Dockerfile
@@ -5,7 +5,7 @@ LABEL Description="Linux Ubuntu 14.04 image with the Swift binaries and tools."
 USER root
 
 # Set environment variables for image
-ENV SWIFT_SNAPSHOT swift-4.1-DEVELOPMENT-SNAPSHOT-2018-03-07-a
+ENV SWIFT_SNAPSHOT swift-4.1-DEVELOPMENT-SNAPSHOT-2018-03-11-a
 ENV SWIFT_SNAPSHOT_LOWERCASE swift-4.1-branch
 ENV UBUNTU_VERSION ubuntu14.04
 ENV UBUNTU_VERSION_NO_DOTS ubuntu1404


### PR DESCRIPTION
update swift41 snapshot build to 2018-03-11-a

bump git hash [ec821ef](https://github.com/apple/swift/commit/ec821efb01e52ee6c5acba90afb34a7150576f3f)