### PR TITLE
update Watson SDK to 0.25.0

### DIFF
--- a/swift4.1/CHANGELOG.md
+++ b/swift4.1/CHANGELOG.md
@@ -1,5 +1,15 @@
 # IBM Functions Swift 4.1 Runtime
 
+
+## 1.4.0
+Changes:
+  - update watson sdk from version `0.24.0` to `0.25.0`
+
+Swift runtime version: [swift-4.1-RELEASE](https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz)
+
+Packages included:
+  - [Watson SDK 0.25.0](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/v0.25.0)
+
 ## 1.3.0
 Changes:
   - update watson sdk from version `0.23.2` to `0.24.0`

--- a/swift4.1/spm-build/Package.swift
+++ b/swift4.1/spm-build/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
       )
     ],
     dependencies: [
-        .package(url: "https://github.com/watson-developer-cloud/swift-sdk", .exact("0.24.0"))
+        .package(url: "https://github.com/watson-developer-cloud/swift-sdk", .exact("0.25.0"))
     ],
     targets: [
       .target(


### PR DESCRIPTION
The Watson SDK has updated from 0.24.0 -> 0.25.0.
This PR simply brings that change into the runtime. 