### PR TITLE
update packages, runtimes bug, and lock travis to repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ deploy:
     on:
       tags: true
       all_branches: true
+      repo: ibm-functions/runtime-swift
   - provider: script
     script: "./tools/travis/publish.sh ibmfunctions 4.1 master"
     on:
       branch: master
+      repo: ibm-functions/runtime-swift
 env:
   global:
   - secure: dndDlFixUN9sua36GlNYq43GucaPmQxQaGtqnRAToKDihTwXqDLksWw8OoXnBqnWMJu/X8j2cx1EAiFmDRO5RdOlILoOx2TqsIEN4Xeu6egLTqr9gri494AuhGC09MLOfVVXW5RsJY2I2D3PoehTNC4u9HxXYJMZp/0Y3kBok+ADp5O3TzC0e5DLFIsQcRxWo81tJ6qraI4xILej8LYPubLT1Zh9hmvWXtXl666gNTrV9vDAROtDU4fAfkv44tv5n5MJNUZWzyYhPpUcmnSetlBVxyX+SrTqvabCYmY0Vg7EvSc6a7fA5YoLpockA2K2VA9+q1Pzns3nDOdVUbt/rRiA5W6+Q5/JH5WkqnjZlGSoez0KXATA4CoSwBXCxuoqwfXlZyEnE71rZv/Kspeeb03I3GQbVihRN0NoAKJwK7AVJMPo4CLLz8WXBWd4Lg4BtTOasZi7gx4jitQ3akfNobxfA0YEb+jNQtRGFuP7KKwfyiz7xuuQoh6X+Q6mOgI/jHBqbilMDYaHLuVc7Avu6BL2UeKw82T1iru74qk2evebRxBaAvp4S0icPYcbBu6gMvNfwU1gj814o61tCn8eBKRR/fKWYSf6TwjutnZ+JRedNYUQA5JSZyQOzJQvQIEZoh8fTACnBJ/QJ6R2DtTGsI17A/ZLLHwM49uP4lVrKm4=

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -27,6 +27,7 @@ invoker_allow_multiple_instances: true
 
 env_hosts_dir: "{{ playbook_dir }}/environments/local"
 
+skip_pull_runtimes: true
 runtimes_manifest:
   defaultImagePrefix: "openwhisk"
   defaultImageTag: "latest"

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -29,8 +29,6 @@ env_hosts_dir: "{{ playbook_dir }}/environments/local"
 
 skip_pull_runtimes: true
 runtimes_manifest:
-  defaultImagePrefix: "openwhisk"
-  defaultImageTag: "latest"
   runtimes:
     nodejs:
     - kind: "nodejs:6"

--- a/swift4.1/CHANGELOG.md
+++ b/swift4.1/CHANGELOG.md
@@ -1,5 +1,14 @@
 # IBM Functions Swift 4.1 Runtime
 
+## 1.8.0
+Changes:
+  - update watson sdk from version `0.27.0` to `0.28.0`
+
+Swift runtime version: [swift-4.1-RELEASE](https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz)
+
+Packages included:
+  - [Watson SDK 0.28.0](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/v0.28.0)
+
 ## 1.7.0
 Changes:
   - update watson sdk from version `0.26.0` to `0.27.0`
@@ -7,7 +16,7 @@ Changes:
 Swift runtime version: [swift-4.1-RELEASE](https://swift.org/builds/swift-4.1-release/ubuntu1404/swift-4.1-RELEASE/swift-4.1-RELEASE-ubuntu14.04.tar.gz)
 
 Packages included:
-  - [Watson SDK 0.26.0](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/v0.26.0)
+  - [Watson SDK 0.27.0](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/v0.27.0)
 
 ## 1.6.0
 Changes:

--- a/swift4.1/spm-build/Package.swift
+++ b/swift4.1/spm-build/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
       )
     ],
     dependencies: [
-        .package(url: "https://github.com/watson-developer-cloud/swift-sdk", .exact("0.27.0"))
+        .package(url: "https://github.com/watson-developer-cloud/swift-sdk", .exact("0.28.0"))
     ],
     targets: [
       .target(

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -20,7 +20,7 @@ docker tag openwhisk/controller ${IMAGE_PREFIX}/controller
 docker pull openwhisk/invoker
 docker tag openwhisk/invoker ${IMAGE_PREFIX}/invoker
 docker pull openwhisk/nodejs6action
-docker tag openwhisk/nodejs6action ${IMAGE_PREFIX}/nodejs6action
+docker tag openwhisk/nodejs6action nodejs6action
 
 TERM=dumb ./gradlew \
 :common:scala:install \


### PR DESCRIPTION
This PR tackles three things:
1) It locks down the deploy section in .travis.yml to only execute when the repo is == 'ibm-functions/runtime-swift'
2) It brings in a fix for an recent change to Runtimes, where we need to skip pulling runtime images
3) It updates the Swift Watson package from 0.27.0 to 0.28.0