### PR TITLE
Add provideApiKeyAnnotationName and update to base image 019024d.

### DIFF
--- a/swift4.1/Dockerfile
+++ b/swift4.1/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile extends Apache OpenWhisk Swift image https://github.com/apache/incubator-openwhisk-runtime-swift/blob/master/core/swift41Action/Dockerfile
 # Using git hash https://github.com/apple/swift/commit/4432bfb0c5cf817119ee88ba6108e7c97e13a331
-FROM openwhisk/action-swift-v4.1:5aacba1
+FROM openwhisk/action-swift-v4.1:019024d
 
 # Add Pre-Installed Pacakges for IBM
 COPY spm-build/Package.swift /swift4Action/spm-build/Package.swift

--- a/swift4.2/Dockerfile
+++ b/swift4.2/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile extends Apache OpenWhisk Swift image https://github.com/apache/incubator-openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile
-FROM openwhisk/action-swift-v4.2:5bb0409
+FROM openwhisk/action-swift-v4.2:019024d
 
 # Add Pre-Installed Pacakges for IBM
 COPY _Whisk.swift /swiftAction/Sources/


### PR DESCRIPTION
- Add the provideApiKeyAnnotationName annotation to the tests that need the api key inside the action. This unblocks the actual failing builds due to these test failures.
- Update to new base image 019024d to get latest security fixes.