### PR TITLE
Adapt testcases to Watson translation response changes.

### DIFF
--- a/tests/src/test/scala/runtime/integration/CredentialsIBMSwiftActionWatsonTests.scala
+++ b/tests/src/test/scala/runtime/integration/CredentialsIBMSwiftActionWatsonTests.scala
@@ -61,7 +61,7 @@ abstract class CredentialsIBMSwiftActionWatsonTests extends TestHelpers with Wsk
     withActivation(wsk.activation, wsk.action.invoke("testWatsonAction")) { activation =>
       val response = activation.response
       response.result.get.fields.get("error") shouldBe empty
-      response.result.get.fields("translation") shouldBe JsString("Hola")
+      response.result.get.fields("translation") shouldBe JsString("hola")
     }
 
   }
@@ -81,7 +81,7 @@ abstract class CredentialsIBMSwiftActionWatsonTests extends TestHelpers with Wsk
     withActivation(wsk.activation, wsk.action.invoke("testWatsonActionCodable")) { activation =>
       val response = activation.response
       response.result.get.fields.get("error") shouldBe empty
-      response.result.get.fields("translation") shouldBe JsString("Hola")
+      response.result.get.fields("translation") shouldBe JsString("hola")
     }
 
   }


### PR DESCRIPTION
  - Watson translation service response changed to be lower case, now. Adjust expected result of the testcases to be lower case, too.