### PR TITLE
Switch translation tests to 'it' as 'es' shows strange results.

### DIFF
--- a/tests/dat/actions/integration/testWatsonAction.swift
+++ b/tests/dat/actions/integration/testWatsonAction.swift
@@ -6,7 +6,7 @@ func main(args: [String:Any]) -> [String:Any] {
     let username = args["username"] as! String
     let password = args["password"] as! String
     let languageTranslator = LanguageTranslator(username: username, password: password, version: "2018-09-16")
-    let request = TranslateRequest(text: ["Hello"], source: "en", target: "es")
+    let request = TranslateRequest(text: ["Hello"], source: "en", target: "it")
     
     let failure = { (error: Error) in print(error) }
     dispatchGroup.enter()

--- a/tests/dat/actions/integration/testWatsonActionCodable.swift
+++ b/tests/dat/actions/integration/testWatsonActionCodable.swift
@@ -13,7 +13,7 @@ struct Output: Codable {
 }
 func main(param: Input, completion: @escaping (Output?, Error?) -> Void) -> Void {
     let languageTranslator = LanguageTranslator(username: param.username , password: param.password, version: "2018-09-16")
-    let request = TranslateRequest(text: ["Hello"], source: "en", target: "es")
+    let request = TranslateRequest(text: ["Hello"], source: "en", target: "it")
     let failure = {(error: Error) in
         print(" calling translate Error")
         print(error)

--- a/tests/dat/actions/integration/testWatsonActionCodableSDK1.swift
+++ b/tests/dat/actions/integration/testWatsonActionCodableSDK1.swift
@@ -13,7 +13,7 @@ struct Output: Codable {
 }
 func main(param: Input, completion: @escaping (Output?, Error?) -> Void) -> Void {
     let languageTranslator = LanguageTranslator(username: param.username , password: param.password, version: "2018-09-16")
-    languageTranslator.translate(text: ["Hello"], source: "en", target: "es") { (response, error) in
+    languageTranslator.translate(text: ["Hello"], source: "en", target: "it") { (response, error) in
         if let error = error {
             print(error)
             return

--- a/tests/dat/actions/integration/testWatsonActionSDK1.swift
+++ b/tests/dat/actions/integration/testWatsonActionSDK1.swift
@@ -8,7 +8,7 @@ func main(args: [String:Any]) -> [String:Any] {
     let languageTranslator = LanguageTranslator(username: username, password: password, version: "2018-09-16")
 
 
-    languageTranslator.translate(text: ["Hello"], source: "en", target: "es") { (response, error) in
+    languageTranslator.translate(text: ["Hello"], source: "en", target: "it" ) { (response, error) in
         if let error = error {
             print(error)
             return

--- a/tests/src/test/scala/runtime/integration/CredentialsIBMSwiftActionWatsonTests.scala
+++ b/tests/src/test/scala/runtime/integration/CredentialsIBMSwiftActionWatsonTests.scala
@@ -61,7 +61,7 @@ abstract class CredentialsIBMSwiftActionWatsonTests extends TestHelpers with Wsk
     withActivation(wsk.activation, wsk.action.invoke("testWatsonAction")) { activation =>
       val response = activation.response
       response.result.get.fields.get("error") shouldBe empty
-      response.result.get.fields("translation") shouldBe JsString("hola")
+      response.result.get.fields("translation") shouldBe JsString("Ciao")
     }
 
   }
@@ -81,7 +81,7 @@ abstract class CredentialsIBMSwiftActionWatsonTests extends TestHelpers with Wsk
     withActivation(wsk.activation, wsk.action.invoke("testWatsonActionCodable")) { activation =>
       val response = activation.response
       response.result.get.fields.get("error") shouldBe empty
-      response.result.get.fields("translation") shouldBe JsString("hola")
+      response.result.get.fields("translation") shouldBe JsString("Ciao")
     }
 
   }


### PR DESCRIPTION
Switch the translation tests to 'it' as the up to now used 'es' now shows the English translation 'Hello' instead of the expected 'Hola'. No idea, why the result now is different than before. This may get fixed in the future, then we can switch back again. For the time being, the translation to 'it' shows the expected translation 'Ciao' and we use that for the tests.