### PR TITLE
Update to newer swift 4.2 parent image.

### DIFF
--- a/swift4.2/CHANGELOG.md
+++ b/swift4.2/CHANGELOG.md
@@ -1,5 +1,17 @@
 # IBM Functions Swift 4.2 Runtime
 
+## 1.4.0
+Changes:
+  - Update to a newer parent image.
+  - Include bug and security fixes.
+  - The action proxy is now build with go 1.15 (was 1.12 before).
+
+Swift runtime version: [swift-4.2.4-RELEASE](https://swift.org/builds/swift-4.2.4-release/ubuntu1604/swift-4.2.4-RELEASE/swift-4.2.4-RELEASE-ubuntu16.04.tar.gz)
+
+Packages included:
+  - [Watson SDK 1.3.1](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/1.3.1)
+
+
 ## 1.3.0
 Changes:
   - Update to a newer base image.

--- a/swift4.2/Dockerfile
+++ b/swift4.2/Dockerfile
@@ -1,7 +1,7 @@
-# Dockerfile extends Apache OpenWhisk Swift image https://github.com/apache/incubator-openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile
-FROM openwhisk/action-swift-v4.2:93881a0
+# Dockerfile extends Apache OpenWhisk Swift image https://github.com/apache/openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile
+FROM openwhisk/action-swift-v4.2:546c7ee
 
-# Add Pre-Installed Pacakges for IBM
+# Add Pre-Installed Packages for IBM
 COPY _Whisk.swift /swiftAction/Sources/
 COPY Package.swift /swiftAction/
 RUN apt-get update \


### PR DESCRIPTION
- New version of the action proxy (https://github.com/apache/openwhisk-runtime-go/archive/1.15@1.16.0.tar.gz) for swift4.2 runtime.
- The new action proxy is now build with go 1.15 (was go 1.12 before).
- Update swift4.2 to Swift 4.2.4.

Reason to do this is to continue to get security fixes.