### PR TITLE
Fix watson tests, remove swift:4.1 build and test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ deploy:
       all_branches: true
       repo: ibm-functions/runtime-swift
   - provider: script
-    script: "./tools/travis/publish.sh ibmfunctions 4.1 master && ./tools/travis/publish.sh ibmfunctions 4.2 master "
+    script: "./tools/travis/publish.sh ibmfunctions 4.2 master "
     on:
       branch: master
       repo: ibm-functions/runtime-swift

--- a/ansible/environments/local/group_vars/all
+++ b/ansible/environments/local/group_vars/all
@@ -37,11 +37,6 @@ runtimes_manifest:
         name: "nodejs6action"
       deprecated: false
     swift:
-    - kind: "swift:4.1"
-      default: false
-      image:
-        name: "action-swift-v4.1"
-      deprecated: false
     - kind: "swift:4.2"
       default: true
       image:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 include 'tests'
 
-include 'swift4.1'
+// include 'swift4.1'
 include 'swift4.2'
 
 rootProject.name = 'runtime-swift-ibm'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -20,11 +20,19 @@ tasks.withType(Test) {
 
 task testWithoutCredentials(type: Test) {
     exclude '**/*Credentials*'
+    
+    // Exclude the swift:4.1 tests as it is deprecated for the blueDeployment.
+    // Once swift:4.1 is fully removed from this repo, the exclude can also be removed.
+    exclude '**/*Swift41*'
 }
 
 // intended for mainBlueWhisk pipeline
 task testBlueCI(type: Test) {
     exclude 'runtime/sdk/**'
+
+    // Exclude the swift:4.1 tests as it is deprecated for the blueDeployment.
+    // Once swift:4.1 is fully removed from this repo, the exclude can also be removed.
+    exclude '**/*Swift41*'
 }
 
 task testBlueDeployment(type: Test) {
@@ -38,10 +46,18 @@ task testBlueDeployment(type: Test) {
 
 task testSDK(type: Test) {
     include 'runtime/sdk/**'
+
+    // Exclude the swift:4.1 tests as it is deprecated for the blueDeployment.
+    // Once swift:4.1 is fully removed from this repo, the exclude can also be removed.
+    exclude '**/*Swift41*'
 }
 
 task testWithoutSDK(type: Test) {
     exclude 'runtime/sdk/**'
+  
+    // Exclude the swift:4.1 tests as it is deprecated for the blueDeployment.
+    // Once swift:4.1 is fully removed from this repo, the exclude can also be removed.
+    exclude '**/*Swift41*'
 }
 
 dependencies {

--- a/tests/dat/actions/integration/testWatsonActionCodableSDK1.swift
+++ b/tests/dat/actions/integration/testWatsonActionCodableSDK1.swift
@@ -6,13 +6,14 @@ import LanguageTranslatorV3
 struct Input: Codable {
     let username: String
     let password: String
-    let url: String?
+    let url: String
 }
 struct Output: Codable {
     let translation: String
 }
 func main(param: Input, completion: @escaping (Output?, Error?) -> Void) -> Void {
     let languageTranslator = LanguageTranslator(username: param.username , password: param.password, version: "2018-09-16")
+    languageTranslator.serviceURL = param.url 
     languageTranslator.translate(text: ["Hello"], source: "en", target: "it") { (response, error) in
         if let error = error {
             print(error)

--- a/tests/dat/actions/integration/testWatsonActionSDK1.swift
+++ b/tests/dat/actions/integration/testWatsonActionSDK1.swift
@@ -5,8 +5,9 @@ func main(args: [String:Any]) -> [String:Any] {
     let _whisk_semaphore = DispatchSemaphore(value: 0)
     let username = args["username"] as! String
     let password = args["password"] as! String
+    let url = args["url"] as! String
     let languageTranslator = LanguageTranslator(username: username, password: password, version: "2018-09-16")
-
+    languageTranslator.serviceURL = url
 
     languageTranslator.translate(text: ["Hello"], source: "en", target: "it" ) { (response, error) in
         if let error = error {

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -38,6 +38,5 @@ docker version
 # Build runtime
 cd $ROOTDIR
 TERM=dumb ./gradlew \
-:swift4.1:distDocker \
 :swift4.2:distDocker \
 -PdockerImagePrefix=${IMAGE_PREFIX}


### PR DESCRIPTION
Update Swift Watson action Tests (swift 4.2) to use the Watson service URL, without the URL the actions take longer than 60 seconds to execute and don`t run. 
changed files:
- testWatsonActionSDK1.swift
-  testWatsonActionCodableSDK1.swift

 Remove Swift 4.1 From Swift Runtime since Swift 4.1 is deprecated by removing the entry's from the following files:
- .travis.yml
- ansible/environments/local/group_vars/all
- settings.gradle
- dified:   tests/build.gradle