### PR TITLE
Update to new action-swift-v4.2 parent to get latest go security fixes.

### DIFF
--- a/swift4.2/CHANGELOG.md
+++ b/swift4.2/CHANGELOG.md
@@ -1,5 +1,15 @@
 # IBM Functions Swift 4.2 Runtime
 
+## 1.4.2
+Changes:
+  - Update to new parent image to get latest go security fixes.
+
+Swift runtime version: [swift-4.2.4-RELEASE](https://swift.org/builds/swift-4.2.4-release/ubuntu1604/swift-4.2.4-RELEASE/swift-4.2.4-RELEASE-ubuntu16.04.tar.gz)
+
+Packages included:
+  - [Watson SDK 1.3.1](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/1.3.1)
+
+
 ## 1.4.1
 Changes:
   - Add `--with-new-pkgs` to `apt-get upgrade` to also install security updates for packages that include new libraries.

--- a/swift4.2/Dockerfile
+++ b/swift4.2/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile extends Apache OpenWhisk Swift image https://github.com/apache/openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile
-FROM openwhisk/action-swift-v4.2:546c7ee
+FROM openwhisk/action-swift-v4.2:8370314
 
 # Add Pre-Installed Packages for IBM
 COPY _Whisk.swift /swiftAction/Sources/


### PR DESCRIPTION
Update to new action-swift-v4.2 parent image to get latest go security fixes.