### PR TITLE
Release 1.4.4 (Update GO_PROXY_RELEASE_VERSION and parent image)

### DIFF
--- a/swift4.2/CHANGELOG.md
+++ b/swift4.2/CHANGELOG.md
@@ -1,5 +1,15 @@
 # IBM Functions Swift 4.2 Runtime
 
+# 1.4.4
+Changes:
+  - Update GO_PROXY_RELEASE_VERSION to 1.15@1.18.0.
+  - Update to new parent image to get latest go security fixes.
+
+Swift runtime version: [swift-4.2.4-RELEASE](https://swift.org/builds/swift-4.2.4-release/ubuntu1804/swift-4.2.4-RELEASE/swift-4.2.4-RELEASE-ubuntu18.04.tar.gz)
+
+Packages included:
+  - [Watson SDK 1.3.1](https://github.com/watson-developer-cloud/swift-sdk/releases/tag/1.3.1)
+
 ## 1.4.3
 Changes:
   - Update to ubuntu 18.04 to continue to receive security fixes.

--- a/swift4.2/Dockerfile
+++ b/swift4.2/Dockerfile
@@ -1,5 +1,5 @@
 # Extend Apache OpenWhisk Swift v4.2 image: https://github.com/apache/openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile
-FROM openwhisk/action-swift-v4.2:abb9474 AS parent_image
+FROM openwhisk/action-swift-v4.2:43eef06 AS parent_image
 
 
 # from https://github.com/apache/openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile
@@ -14,7 +14,7 @@ RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
 
 # Build go action-loop proxy from release.
 FROM golang:1.15 AS builder_release
-ARG GO_PROXY_RELEASE_VERSION=1.15@1.17.0
+ARG GO_PROXY_RELEASE_VERSION=1.15@1.18.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\
   | tar xzf -\


### PR DESCRIPTION
  - Update GO_PROXY_RELEASE_VERSION to 1.15@1.18.0.
  - Update to new parent image to get latest go security fixes.