### PR TITLE
Update to azure-storage-blob:12.7.0.

### DIFF
--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -14,9 +14,14 @@ cd $HOMEDIR
 git clone https://github.com/apache/openwhisk.git openwhisk
 cd openwhisk
 # Use a fixed commit to run the tests, to explicitly control when changes are consumed.
-# Commit:  Update the notice year (#5122) 
+# Commit:  Update the notice year (#5122)
 git checkout ecb2a980659f28d0adbd9ef837afaf4cb2b695bf
 
+# Work around for the missing azure-storage-blob:12.6.0 issue.
+# Version 12.6.0 was removed from maven central. Patching the code to use 12.7.0 instead.
+# Adapting to an updated version of apache/openwhisk takes some more effort and will be done later on.
+echo "Update openwhisk/common/scala/build.gradle to azure-storage-blob:12.7.0"
+sed -i "s/com\.azure:azure-storage-blob:12\.6\.0/com.azure:azure-storage-blob:12.7.0/" common/scala/build.gradle
 
 ./tools/travis/setup.sh
 


### PR DESCRIPTION
The version 12.6.0 of azure-storage-blob was removed from maven central. Patching the code to use 12.7.0 instead.
Adapting to an updated version of apache/openwhisk takes some more effort and will be done later on.