### PR TITLE
Build swift:4.2 runtime image with --no-cache.

### DIFF
--- a/swift4.2/build.gradle
+++ b/swift4.2/build.gradle
@@ -1,6 +1,11 @@
 ext.dockerImageName = 'action-swift-v4.2'
 apply from: '../gradle/docker.gradle'
 
+// To always get the latest vulnerability updates into the image, use --no-cache for building the image.
+// This is not needed for travis builds (the VM is always new), but for local development.
+dockerBuildArg = ['build','--no-cache']
+
+
 distDocker.dependsOn 'copyWhisk'
 distDocker.finalizedBy('cleanup')
 


### PR DESCRIPTION
- Run docker build with --no-cache for swift:4.2 to always get latest security updates into the image. For travis builds this is not required (travis vm is always empty). But local builds usually use the cache to speed up the build. They would not get the updates unless the Dockerfile is changed somewhere before the update/upgrade or the docker cache is cleared.