### PR TITLE
Do not rebuild image for publish.

### DIFF
--- a/tools/travis/publish.sh
+++ b/tools/travis/publish.sh
@@ -26,7 +26,7 @@ fi
 
 if [[ ! -z ${RUNTIME} ]]; then
 TERM=dumb ./gradlew \
-:${RUNTIME}:distDocker \
+:${RUNTIME}:pushImage \
 -PdockerRegistry=docker.io \
 -PdockerImagePrefix=${IMAGE_PREFIX} \
 -PdockerImageTag=${IMAGE_TAG}
@@ -35,7 +35,7 @@ TERM=dumb ./gradlew \
   if [ ${IMAGE_TAG} == "master" ]; then
   SHORT_COMMIT=`git rev-parse --short HEAD`
   TERM=dumb ./gradlew \
-  :${RUNTIME}:distDocker \
+  :${RUNTIME}:pushImage \
   -PdockerRegistry=docker.io \
   -PdockerImagePrefix=${IMAGE_PREFIX} \
   -PdockerImageTag=${SHORT_COMMIT}


### PR DESCRIPTION
- Avoid to rebuild the image before pushing it to the image repository. The distDocker target does an docker build before tagging and pushing to the image repository. Depending on how the docker cache is used, this causes a full rebuild of the image. But we want to push the already built and tested image not a newly created one. Therefore we now use the pushImage target. It only does a tag and a push without a docker build. In case the image does not exist (no build before), it will fail.